### PR TITLE
Fix Background Video Scrollbar Issue

### DIFF
--- a/src/components/BgVideo/BgVideo.scss
+++ b/src/components/BgVideo/BgVideo.scss
@@ -1,7 +1,7 @@
 .bg-video {
-  position: absolute;
+  position: fixed;
   height: 100vh;
-  width: 100%;
+  width: 100vw;
   z-index: -100;
   top: 0;
   bottom: 0;


### PR DESCRIPTION
Fullscreen background video was slightly larger
than the viewport on Firefox.
Change position attribute to fixed to fix the issue.